### PR TITLE
Request offsets from the hazedumper repository.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Idea
+.idea

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Pymem==1.0
 #pywin32
+
+requests~=2.20.0


### PR DESCRIPTION
Found someone trying to pass this script off as their own on UC.
After using it a couple of times the one downside was I had to manually update after noticing some of the signatures/netvars had changed.

I have added a small function to retrieve these values on startup.

It's worth noting hazedumper do not update their values immediately however I imagine the average joe finds their offsets from the dumps anyway.

To circumvent this you could catch the exception and fallback to manual input.